### PR TITLE
Improve GAT speed

### DIFF
--- a/graph_nn/gat.py
+++ b/graph_nn/gat.py
@@ -1,13 +1,11 @@
 from functools import partial
-from typing import List
 
 import torch
 import torch.nn.functional as F
 from torch import nn
 
 from .types import _Activation
-from .utils import init_glorot_uniform
-
+from .utils import init_glorot_uniform, sparse_aggregate, sparse_row_softmax
 
 __all__ = ["GATLayer"]
 
@@ -44,59 +42,19 @@ class GATLayer(nn.Module):
         init_glorot_uniform(self.dst_attn, self.head_dim * 2, 1)
 
     def forward(self, x: torch.Tensor, edge_indices: torch.Tensor) -> torch.Tensor:
+        row_idx, col_idx = edge_indices[0], edge_indices[1]
         x = self.linear(x).reshape(-1, self.num_heads, self.head_dim)
-        
-        src_attn = F.embedding(edge_indices[0], (x * self.src_attn).sum(dim=-1))
-        dst_attn = F.embedding(edge_indices[1], (x * self.dst_attn).sum(dim=-1))
+
+        src_attn = F.embedding(row_idx, (x * self.src_attn).sum(dim=-1))
+        dst_attn = F.embedding(col_idx, (x * self.dst_attn).sum(dim=-1))
         attn_coef = self.act(src_attn + dst_attn)
-        # attn_mat = torch.sparse_coo_tensor(edge_indices, attn_coef, requires_grad=True)
-        # attn_weights = torch.sparse.softmax(attn_mat, dim=1).coalesce()
 
-        # It might be more efficient to apply edge dropping to inputs
-        # instead of applying dropout to softmax weights
-        # indices = attn_weights.indices()
-        # values = self.dropout(attn_weights.values())
-        values = sparse_softmax(edge_indices, attn_coef, 1, [x.shape[0], x.shape[0], self.num_heads])
-        values = self.dropout(values)
+        values = sparse_row_softmax(row_idx, attn_coef, x.shape[0])
+        values = self.dropout(values)  # DropEdge might be more efficient
 
-        # head_outputs = []
-        # for i in range(self.num_heads):
-        #     w_i = torch.sparse_coo_tensor(indices, values[:, i], requires_grad=True)
-        #     head_outputs.append(torch.sparse.mm(w_i, x[:, i]))
-
-        # if self.aggregate == "concat":
-        #     return torch.cat(head_outputs, dim=1)
-        # if self.aggregate == "mean":
-        #     return sum(head_outputs) / self.num_heads
-
-        values = x[edge_indices[1]] * values.unsqueeze(2)
-        out = torch.zeros_like(x)
-        out = out.scatter_add_(0, edge_indices[0, :, None, None].expand_as(values), values)
+        values = x[col_idx] * values.unsqueeze(2)
+        x = sparse_aggregate(row_idx, values, x.shape[0])
         if self.aggregate == "concat":
-            return out.flatten(1)
+            return x.flatten(1)
         if self.aggregate == "mean":
-            return out.mean(1)
-
-
-def sparse_softmax(indices: torch.Tensor, values: torch.Tensor, dim: int, shape: List[int]) -> torch.Tensor:
-    sparse_dim, dense_dim = indices.shape[0], values.dim() - 1
-    assert dim < sparse_dim + dense_dim
-    if dim >= sparse_dim:
-        return values.softmax(dim - sparse_dim)
-
-    index = indices[dim]
-    reduce_shape = list(shape)
-    reduce_shape.pop(dim)
-    max_val = torch.zeros(reduce_shape, device=values.device)
-
-    index_shape = list(index.shape) + [1] * dense_dim
-    index_scatter = index.view(index_shape).expand_as(values)
-    max_val = max_val.scatter_reduce(0, index_scatter, values, reduce="amax", include_self=False)
-    values = values - max_val[index]
-    
-    values = values.exp()
-    sum_val = torch.zeros(reduce_shape, device=values.device)
-    sum_val = sum_val.scatter_add_(0, index_scatter, values)
-    values = values / sum_val[index]
-
-    return values
+            return x.mean(1)

--- a/graph_nn/gat.py
+++ b/graph_nn/gat.py
@@ -1,4 +1,5 @@
 from functools import partial
+from typing import List
 
 import torch
 import torch.nn.functional as F
@@ -44,24 +45,58 @@ class GATLayer(nn.Module):
 
     def forward(self, x: torch.Tensor, edge_indices: torch.Tensor) -> torch.Tensor:
         x = self.linear(x).reshape(-1, self.num_heads, self.head_dim)
-
+        
         src_attn = F.embedding(edge_indices[0], (x * self.src_attn).sum(dim=-1))
         dst_attn = F.embedding(edge_indices[1], (x * self.dst_attn).sum(dim=-1))
         attn_coef = self.act(src_attn + dst_attn)
-        attn_mat = torch.sparse_coo_tensor(edge_indices, attn_coef, requires_grad=True)
-        attn_weights = torch.sparse.softmax(attn_mat, dim=1).coalesce()
+        # attn_mat = torch.sparse_coo_tensor(edge_indices, attn_coef, requires_grad=True)
+        # attn_weights = torch.sparse.softmax(attn_mat, dim=1).coalesce()
 
         # It might be more efficient to apply edge dropping to inputs
         # instead of applying dropout to softmax weights
-        indices = attn_weights.indices()
-        values = self.dropout(attn_weights.values())
+        # indices = attn_weights.indices()
+        # values = self.dropout(attn_weights.values())
+        values = sparse_softmax(edge_indices, attn_coef, 1, [x.shape[0], x.shape[0], self.num_heads])
+        values = self.dropout(values)
 
-        head_outputs = []
-        for i in range(self.num_heads):
-            w_i = torch.sparse_coo_tensor(indices, values[:, i], requires_grad=True)
-            head_outputs.append(torch.sparse.mm(w_i, x[:, i]))
+        # head_outputs = []
+        # for i in range(self.num_heads):
+        #     w_i = torch.sparse_coo_tensor(indices, values[:, i], requires_grad=True)
+        #     head_outputs.append(torch.sparse.mm(w_i, x[:, i]))
 
+        # if self.aggregate == "concat":
+        #     return torch.cat(head_outputs, dim=1)
+        # if self.aggregate == "mean":
+        #     return sum(head_outputs) / self.num_heads
+
+        values = x[edge_indices[1]] * values.unsqueeze(2)
+        out = torch.zeros_like(x)
+        out = out.scatter_add_(0, edge_indices[0, :, None, None].expand_as(values), values)
         if self.aggregate == "concat":
-            return torch.cat(head_outputs, dim=1)
+            return out.flatten(1)
         if self.aggregate == "mean":
-            return sum(head_outputs) / self.num_heads
+            return out.mean(1)
+
+
+def sparse_softmax(indices: torch.Tensor, values: torch.Tensor, dim: int, shape: List[int]) -> torch.Tensor:
+    sparse_dim, dense_dim = indices.shape[0], values.dim() - 1
+    assert dim < sparse_dim + dense_dim
+    if dim >= sparse_dim:
+        return values.softmax(dim - sparse_dim)
+
+    index = indices[dim]
+    reduce_shape = list(shape)
+    reduce_shape.pop(dim)
+    max_val = torch.zeros(reduce_shape, device=values.device)
+
+    index_shape = list(index.shape) + [1] * dense_dim
+    index_scatter = index.view(index_shape).expand_as(values)
+    max_val = max_val.scatter_reduce(0, index_scatter, values, reduce="amax", include_self=False)
+    values = values - max_val[index]
+    
+    values = values.exp()
+    sum_val = torch.zeros(reduce_shape, device=values.device)
+    sum_val = sum_val.scatter_add_(0, index_scatter, values)
+    values = values / sum_val[index]
+
+    return values

--- a/graph_nn/utils.py
+++ b/graph_nn/utils.py
@@ -1,10 +1,16 @@
 from typing import Optional
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 
-
-__all__ = ["append_identity_matrix", "init_glorot_uniform", "Dropout"]
+__all__ = [
+    "append_identity_matrix",
+    "init_glorot_uniform",
+    "Dropout",
+    "sparse_row_softmax",
+    "sparse_aggregate",
+]
 
 
 def append_identity_matrix(
@@ -26,9 +32,61 @@ def init_glorot_uniform(
 
 class Dropout(nn.Dropout):
     """Dropout with support for sparse COO tensors."""
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if x.is_sparse:
             x = x.coalesce()
             values = super().forward(x.values())
             return torch.sparse_coo_tensor(x.indices(), values, x.size())
         return super().forward(x)
+
+
+def sparse_row_softmax(
+    row_idx: torch.Tensor, values: torch.Tensor, num_nodes: int
+) -> torch.Tensor:
+    """Apply softmax for each row (i.e. apply over column dimension).
+    Values can represent N-dim weight coefficients, such as multi-head mechanism in GAT.
+
+    This is equivalent to `torch.sparse.softmax(torch.sparse_coo_tensor(indices, values), dim=1).coalesce().values()`.
+
+    Args:
+        row_idx: row indices. Shape (nnz,)
+        values: weight coefficients. Shape (nnz, dim1, dim2, ...)
+        num_nodes: number of nodes
+    """
+
+    reduced_shape = (num_nodes,) + values.shape[1:]
+    expanded_row_idx = row_idx.view([-1] + [1] * (values.dim() - 1)).expand_as(values)
+
+    # Tensor.scatter_reduce() is only available in PyTorch 1.12
+    if torch.__version__ >= (1, 12, 0):
+        max_val = torch.zeros(reduced_shape, device=values.device)
+        max_val = max_val.scatter_reduce(
+            0, expanded_row_idx, values, reduce="amax", include_self=False
+        )
+        values = values - F.embedding(row_idx, max_val)
+
+    values = values.exp()
+    sum_val = torch.zeros(reduced_shape, device=values.device)
+    sum_val = sum_val.scatter_add_(0, expanded_row_idx, values)
+    values = values / F.embedding(row_idx, sum_val)
+
+    return values
+
+
+def sparse_aggregate(
+    row_idx: torch.Tensor, values: torch.Tensor, num_nodes: int
+) -> torch.Tensor:
+    """Aggregate N-dim features from neighbors. This can be used for multi-head mechanism in GAT.
+    
+    This is equivalent to `torch.sparse.sum(torch.sparse_coo_tensor(indices, values), dim=1).to_dense()`.
+
+    Args:
+        row_idx: row indices. Shape (nnz,)
+        values: features from neighbors. Shape (nnz, dim1, dim2, ...)
+        num_nodes: number of nodes
+    """
+
+    row_idx = row_idx.view([-1] + [1] * (values.dim() - 1)).expand_as(values)
+    out = torch.zeros((num_nodes,) + values.shape[1:], device=values.device)
+    return out.scatter_add_(0, row_idx, values)


### PR DESCRIPTION
Built-in PyTorch operations on sparse tensors are often inefficient since we cannot work directly on `indices` and `values` tensors. Moreover, multi-head mechanism in GAT makes feature aggregation via matrix multiplication awkward and inefficient. Thus the following operations are re-written to use PyTorch primitives (similar to PyTorch Geometric, but does not rely on `torch-sparse`):

- softmax: a common numerical stability trick is to subtract max value from each row before calculating softmax. This requires `Tensor.scatter_reduce(..., reduce="amax")`. Although this operation first appears in PyTorch 1.11, this was an error. The API is still in beta in PyTorch 1.12. Therefore this trick is only applied for PyTorch 1.12.
- feature aggregation: sum of features from the neighbors (i.e. messages)

For both functions above, although they were said to calculate for each row (across column dimension), simply passing `col_idx` instead will let them calculate for each column (across row dimension).

Cora training time (Python 3.10, PyTorch 1.12)

```bash
python main.py --model gat --dataset Cora --dropout 0.6 --l2_regularization 5e-4 --lr 5e-3 --num_epochs 1000
```

Commit | cpu (Intel(R) Xeon(R) W-2295) | gpu (Nvidia RTX 3090)
--------|--------------------------------|------------------------
869e9a2f | 76.94s | 40.24s
e86f46e5 | 19.46s | 16.34s

These improvements will also benefit Graph Transformer when I implement it.